### PR TITLE
Add sprite build rules for Team Algorithm and Team Blockchain

### DIFF
--- a/spritesheet_rules.mk
+++ b/spritesheet_rules.mk
@@ -201,6 +201,35 @@ $(OBJEVENTGFXDIR)/people/team_magma/maxie.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -mwidth 2 -mheight 4
 
 
+$(OBJEVENTGFXDIR)/people/team_algorithm/algorithm_member_m.4bpp: %.4bpp: %.png
+	$(GFX) $< $@ -mwidth 2 -mheight 4
+
+$(OBJEVENTGFXDIR)/people/team_algorithm/algorithm_member_f.4bpp: %.4bpp: %.png
+	$(GFX) $< $@ -mwidth 2 -mheight 4
+
+$(OBJEVENTGFXDIR)/people/team_algorithm/algorithm_admin_m.4bpp: %.4bpp: %.png
+	$(GFX) $< $@ -mwidth 2 -mheight 4
+
+$(OBJEVENTGFXDIR)/people/team_algorithm/algorithm_admin_f.4bpp: %.4bpp: %.png
+	$(GFX) $< $@ -mwidth 2 -mheight 4
+
+$(OBJEVENTGFXDIR)/people/team_algorithm/algorithm_leader.4bpp: %.4bpp: %.png
+	$(GFX) $< $@ -mwidth 2 -mheight 4
+
+
+$(OBJEVENTGFXDIR)/people/team_blockchain/blockchain_member_m.4bpp: %.4bpp: %.png
+	$(GFX) $< $@ -mwidth 2 -mheight 4
+
+$(OBJEVENTGFXDIR)/people/team_blockchain/blockchain_member_f.4bpp: %.4bpp: %.png
+	$(GFX) $< $@ -mwidth 2 -mheight 4
+
+$(OBJEVENTGFXDIR)/people/team_blockchain/blockchain_admin.4bpp: %.4bpp: %.png
+	$(GFX) $< $@ -mwidth 2 -mheight 4
+
+$(OBJEVENTGFXDIR)/people/team_blockchain/blockchain_leader.4bpp: %.4bpp: %.png
+	$(GFX) $< $@ -mwidth 2 -mheight 4
+
+
 $(OBJEVENTGFXDIR)/people/artist.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -mwidth 2 -mheight 4
 


### PR DESCRIPTION
The overworld sprites for Team Algorithm and Team Blockchain (added in
this fork) rendered as garbled tiles because spritesheet_rules.mk had no
matching rules for their PNGs. Without the explicit -mwidth 2 -mheight 4
flags that every other 16x32 NPC uses, the default build pattern
serialized each 144x32 sheet as a flat 8x8 tile stream instead of nine
2x4-tile frames, so overworld_ascending_frames(..., 2, 4) indexed
mismatched tile data. Fixes #102.