### PR TITLE
Fix SPECIES_BASCULIN_HISUI undeclared error in trainers.party

### DIFF
--- a/src/data/trainers.party
+++ b/src/data/trainers.party
@@ -120,7 +120,7 @@ Noibat
 Level: 31
 IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe
 
-Basculin-Hisui
+Basculin-White-Striped
 Level: 31
 IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe
 
@@ -146,7 +146,7 @@ Music: Aqua
 Double Battle: No
 AI: Check Bad Move
 
-Basculin-Hisui
+Basculin-White-Striped
 Level: 32
 IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe
 
@@ -172,7 +172,7 @@ Music: Aqua
 Double Battle: No
 AI: Check Bad Move
 
-Basculin-Hisui
+Basculin-White-Striped
 Level: 36
 IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe
 
@@ -296,7 +296,7 @@ Music: Aqua
 Double Battle: No
 AI: Check Bad Move
 
-Basculin-Hisui
+Basculin-White-Striped
 Level: 36
 IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe
 
@@ -356,7 +356,7 @@ Murkrow
 Level: 27
 IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe
 
-Basculin-Hisui
+Basculin-White-Striped
 Level: 27
 IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe
 
@@ -377,7 +377,7 @@ Noibat
 Level: 26
 IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe
 
-Basculin-Hisui
+Basculin-White-Striped
 Level: 26
 IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe
 
@@ -390,7 +390,7 @@ Music: Aqua
 Double Battle: No
 AI: Check Bad Move
 
-Basculin-Hisui
+Basculin-White-Striped
 Level: 15
 IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe
 
@@ -407,7 +407,7 @@ Noibat
 Level: 14
 IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe
 
-Basculin-Hisui
+Basculin-White-Striped
 Level: 14
 IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe
 
@@ -446,7 +446,7 @@ Music: Aqua
 Double Battle: No
 AI: Check Bad Move
 
-Basculin-Hisui
+Basculin-White-Striped
 Level: 32
 IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe
 
@@ -463,7 +463,7 @@ Murkrow
 Level: 30
 IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe
 
-Basculin-Hisui
+Basculin-White-Striped
 Level: 30
 IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe
 
@@ -476,7 +476,7 @@ Music: Aqua
 Double Battle: No
 AI: Check Bad Move
 
-Basculin-Hisui
+Basculin-White-Striped
 Level: 28
 IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe
 
@@ -489,7 +489,7 @@ Music: Aqua
 Double Battle: No
 AI: Check Bad Move
 
-Basculin-Hisui
+Basculin-White-Striped
 Level: 32
 IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe
 
@@ -563,7 +563,7 @@ Music: Aqua
 Double Battle: No
 AI: Basic Trainer
 
-Basculin-Hisui
+Basculin-White-Striped
 Level: 28
 IVs: 6 HP / 6 Atk / 6 Def / 6 SpA / 6 SpD / 6 Spe
 
@@ -2259,7 +2259,7 @@ Music: Female
 Double Battle: No
 AI: Check Bad Move
 
-Basculin-Hisui
+Basculin-White-Striped
 Level: 39
 IVs: 12 HP / 12 Atk / 12 Def / 12 SpA / 12 SpD / 12 Spe
 
@@ -2565,7 +2565,7 @@ Music: Swimmer
 Double Battle: No
 AI: Check Bad Move
 
-Basculin-Hisui
+Basculin-White-Striped
 Level: 26
 IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe
 
@@ -2629,7 +2629,7 @@ Music: Swimmer
 Double Battle: No
 AI: Check Bad Move
 
-Basculin-Hisui
+Basculin-White-Striped
 Level: 26
 IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe
 
@@ -2655,7 +2655,7 @@ Music: Swimmer
 Double Battle: No
 AI: Check Bad Move
 
-Basculin-Hisui
+Basculin-White-Striped
 Level: 26
 IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe
 
@@ -2672,7 +2672,7 @@ Qwilfish-Hisui
 Level: 25
 IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe
 
-Basculin-Hisui
+Basculin-White-Striped
 Level: 25
 IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe
 
@@ -2702,7 +2702,7 @@ Music: Swimmer
 Double Battle: No
 AI: Check Bad Move
 
-Basculin-Hisui
+Basculin-White-Striped
 Level: 34
 IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe
 
@@ -2754,7 +2754,7 @@ Music: Swimmer
 Double Battle: No
 AI: Check Bad Move
 
-Basculin-Hisui
+Basculin-White-Striped
 Level: 31
 IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe
 
@@ -2762,7 +2762,7 @@ Pikipek
 Level: 31
 IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe
 
-Basculin-Hisui
+Basculin-White-Striped
 Level: 31
 IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe
 
@@ -3211,7 +3211,7 @@ Music: Aqua
 Double Battle: No
 AI: Check Bad Move
 
-Basculin-Hisui
+Basculin-White-Striped
 Level: 32
 IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe
 
@@ -5804,7 +5804,7 @@ Panpour
 Level: 17
 IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe
 
-Basculin-Hisui
+Basculin-White-Striped
 Level: 18
 IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe
 
@@ -5876,7 +5876,7 @@ Music: Hiker
 Double Battle: No
 AI: Check Bad Move
 
-Basculin-Hisui
+Basculin-White-Striped
 Level: 19
 IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe
 
@@ -5893,7 +5893,7 @@ Qwilfish-Hisui
 Level: 25
 IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe
 
-Basculin-Hisui
+Basculin-White-Striped
 Level: 25
 IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe
 
@@ -5961,7 +5961,7 @@ Milotic
 Level: 29
 IVs: 2 HP / 2 Atk / 2 Def / 2 SpA / 2 SpD / 2 Spe
 
-Basculin-Hisui
+Basculin-White-Striped
 Level: 26
 IVs: 2 HP / 2 Atk / 2 Def / 2 SpA / 2 SpD / 2 Spe
 
@@ -5986,7 +5986,7 @@ Milotic
 Level: 31
 IVs: 3 HP / 3 Atk / 3 Def / 3 SpA / 3 SpD / 3 Spe
 
-Basculin-Hisui
+Basculin-White-Striped
 Level: 30
 IVs: 3 HP / 3 Atk / 3 Def / 3 SpA / 3 SpD / 3 Spe
 
@@ -9901,7 +9901,7 @@ Music: Swimmer
 Double Battle: No
 AI: Check Bad Move
 
-Basculin-Hisui
+Basculin-White-Striped
 Level: 34
 IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe
 
@@ -11566,7 +11566,7 @@ Music: Hiker
 Double Battle: No
 AI: Check Bad Move
 
-Basculin-Hisui
+Basculin-White-Striped
 Level: 31
 IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe
 
@@ -11895,7 +11895,7 @@ Toxel
 Level: 34
 IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe
 
-Basculin-Hisui
+Basculin-White-Striped
 Level: 33
 IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe
 
@@ -11912,7 +11912,7 @@ Toxel
 Level: 42
 IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe
 
-Basculin-Hisui
+Basculin-White-Striped
 Level: 40
 IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe
 
@@ -11929,7 +11929,7 @@ Toxtricity
 Level: 45
 IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe
 
-Basculin-Hisui
+Basculin-White-Striped
 Level: 43
 IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe
 
@@ -12005,7 +12005,7 @@ Feebas
 Level: 26
 IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe
 
-Basculin-Hisui
+Basculin-White-Striped
 Level: 23
 IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe
 
@@ -12306,7 +12306,7 @@ Music: Hiker
 Double Battle: No
 AI: Check Bad Move
 
-Basculin-Hisui
+Basculin-White-Striped
 Level: 19
 IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe
 


### PR DESCRIPTION
Replace all 'Basculin-Hisui' references with 'Basculin-White-Striped',
which maps to the existing SPECIES_BASCULIN_WHITE_STRIPED constant.
Hisuian Basculin is the White-Striped form; there is no separate
SPECIES_BASCULIN_HISUI constant defined.

https://claude.ai/code/session_0158JxfJ5HY4g7H1m9GyzVK2